### PR TITLE
Fix cross-platform type issue and lint warning

### DIFF
--- a/wasmedge_plugin_sdk/src/sdk/plugin.rs
+++ b/wasmedge_plugin_sdk/src/sdk/plugin.rs
@@ -177,7 +177,7 @@ impl OptionString {
 impl Drop for OptionString {
     fn drop(&mut self) {
         unsafe {
-            Box::from_raw(self.buf as *mut i8);
+            drop(Box::from_raw(self.buf as *mut i8));
         }
     }
 }
@@ -196,7 +196,7 @@ impl Placeholder for OptionString {
     fn create_placeholder() -> Box<Self> {
         let length: u32 = 128;
         let buf = vec![0i8; length as usize].into_boxed_slice();
-        let buf_ptr = Box::into_raw(buf) as *const u8;
+        let buf_ptr = Box::into_raw(buf) as *const ::std::os::raw::c_char;
         Box::new(OptionString {
             length,
             buf: buf_ptr,


### PR DESCRIPTION
1. The type ::std::os::raw::c_char is implemented differently on macOS and Ubuntu. One platform uses *i8 while the other uses *u8. Previously, directly applying the type from cargo lint was incorrect, causing compilation failures on one of the platforms.
2. Apply lint suggestions to fix the unused return value of Box::<T>::from_raw that must be used. Call drop(Box::from_raw(ptr)) if you intend to drop the Box.